### PR TITLE
Added no-dependency installation of ipywidgets

### DIFF
--- a/bin/pyenv-register-kernel
+++ b/bin/pyenv-register-kernel
@@ -25,6 +25,7 @@ kernel_dir=${jupyter_dir}/kernels/${name}
 echo "Installing jupyter kernel file $name for $python to $kerneldir ..."
 
 PYENV_VERSION=$name pyenv exec pip install -U ipykernel
+PYENV_VERSION=$name pyenv exec pip install -U --no-deps ipywidgets
 
 mkdir -p $kernel_dir
 


### PR DESCRIPTION
ipywidgets is needed for displaying `IProgress` progress bars for example. it needs to be installed with the `--no-deps` flag because otherwise the whole notebook will be installed (see here: https://github.com/jupyter-widgets/ipywidgets/issues/1892)