### PR TITLE
Updating jupyter kernel call

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ pyenv versions --bare | grep -v "/" | xargs -L 1 pyenv register-kernel
 To start up an interactive shell using the kernel for your currently active `pyenv` version:
 
 ```shell
-jupyter console --kernel=$(pyenv version)
+jupyter console --kernel=$(pyenv version | awk '{print $1}')
 ```
 
 It might be useful to add an alias in your init file:
 
 ```shell
-alias ipy='jupyter console --kernel=$(pyenv version)'
+alias ipy="jupyter console --kernel=$(pyenv version | awk '{print $1}')"
 ```

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ pyenv versions --bare | grep -v "/" | xargs -L 1 pyenv register-kernel
 To start up an interactive shell using the kernel for your currently active `pyenv` version:
 
 ```shell
-jupyter console --kernel=$(pyenv version | awk '{print $1}')
+jupyter console --kernel=$(pyenv version | head -n1 | cut -d ' ' -f1)
 ```
 
 It might be useful to add an alias in your init file:
 
 ```shell
-alias ipy="jupyter console --kernel=$(pyenv version | awk '{print $1}')"
+alias ipy="jupyter console --kernel=$(pyenv version | head -n1 | cut -d ' ' -f1)"
 ```


### PR DESCRIPTION
Updating the command for setting the kernel for Jupyter consoles.
Makes it more robust and makes it work on more resent releases of pyenv, with and without local environments set.

Calling  `pyenv version` prints
```shell
$ pyenv version
3.8.5 (set by /home/markussagen/.pyenv/version)
```

Changing `pyenv version` to `pyenv version | awk '{print $1}'` ensures that everything still works as expected