### PR TITLE
Change register-kernel to manual kernel registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pyenv-jupyter-kernel
 
-Pyenv plugin to create a jupyter kernel for every installed pyenv version. Inspiration from [this gist](https://gist.github.com/thvitt/9072336288921f57ec8741eb4b8b024e)
+Pyenv plugin to create a jupyter kernel for installed pyenv version. Inspiration from [this gist](https://gist.github.com/thvitt/9072336288921f57ec8741eb4b8b024e)
 
 ## Installation
 
@@ -10,7 +10,7 @@ $ git clone https://github.com/aiguofer/pyenv-jupyter-kernel $(pyenv root)/plugi
 
 ## Usage
 
-New kernels are automatically installed for every new version and virtualenv that you install. However, if you want to install the kernel for the current version (if using multiple versions, the top one) you can run:
+If you want to install the kernel for the current version (if using multiple versions, the top one) you run:
 
 ```shell
 $ pyenv register-kernel

--- a/bin/pyenv-register-kernel
+++ b/bin/pyenv-register-kernel
@@ -8,6 +8,17 @@
 # it will use the current active version. If there is more than one
 # active version, it will use the first one.
 
+# Function to check if a Python package is installed
+check_python_package_installed() {
+    local package=$1
+    PYENV_VERSION=$name pyenv exec pip list --disable-pip-version-check | grep -F "$package" > /dev/null
+    if [ $? -eq 0 ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 set -e
 [ -n "$PYENV_DEBUG" ] && set -x
 
@@ -19,25 +30,20 @@ fi
 
 python=$(PYENV_VERSION=$name pyenv which python)
 
-jupyter_dir=$(jupyter --data-dir)
-kernel_dir=${jupyter_dir}/kernels/pyenv_${name}
+# Check if Jupyter is installed
+if check_python_package_installed "jupyter"; then
+    jupyter_dir=$(PYENV_VERSION=$name pyenv exec jupyter --data-dir)
+    kernel_dir=${jupyter_dir}/kernels/pyenv_${name}
 
-echo "Installing jupyter kernel file $name for $python to $kernel_dir ..."
+    echo "Installing jupyter kernel file $name for $python to $kernel_dir ..."
 
-echo "Upgrading (or installing) the ipykernel package for $name ..."
-PYENV_VERSION=$name pyenv exec pip install -U ipykernel
-PYENV_VERSION=$name pyenv exec pip install -U --no-deps ipywidgets
+    echo "Upgrading (or installing) the ipykernel package for $name ..."
+    PYENV_VERSION=$name pyenv exec pip install -U --disable-pip-version-check ipykernel
+    PYENV_VERSION=$name pyenv exec pip install -U --no-deps --disable-pip-version-check ipywidgets
 
-mkdir -p $kernel_dir
-
-kernel_file=${kernel_dir}/kernel.json
-
-cat > $kernel_file <<EOF
-{
-    "argv": [ "$python", "-m", "ipykernel", "-f", "{connection_file}" ],
-    "display_name": "$name",
-    "language": "python"
-}
-EOF
-
-echo "Kernel file created."
+    echo "Creating kernel..."
+    PYENV_VERSION=$name pyenv exec python -m ipykernel install --user --name pyenv_$name --display-name "pyenv_$name"
+    echo "Kernel file created."
+else
+    echo "Jupyter is not installed in the pyenv environment '$name'."
+fi

--- a/etc/pyenv.d/install/register-jupyter-kernel.bash
+++ b/etc/pyenv.d/install/register-jupyter-kernel.bash
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-if declare -Ff after_install >/dev/null; then
-  after_install 'pyenv register-kernel $VERSION_NAME'
-else
-  echo "pyenv: pyenv-jupyter-kernel plugin requires pyenv v0.1.0 or later" >&2
-fi

--- a/etc/pyenv.d/uninstall/remove-jupyter-kernel.bash
+++ b/etc/pyenv.d/uninstall/remove-jupyter-kernel.bash
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
+env_name=$1
 
-if declare -Ff after_uninstall >/dev/null; then
-    after_uninstall 'rm -rf $(jupyter --data-dir)/kernels/${VERSION_NAME}'
+check_python_package_installed() {
+    local package=$1
+    PYENV_VERSION=$env_name pyenv exec pip list --disable-pip-version-check | grep -F "$package" > /dev/null
+    if [ $? -eq 0 ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+if declare -Ff before_uninstall >/dev/null; then
+    if check_python_package_installed "jupyter"; then
+        jupyter_data_dir=$(PYENV_VERSION=$env_name pyenv exec jupyter --data-dir)
+        before_uninstall 'rm -rf ${jupyter_data_dir}/kernels/pyenv_${env_name}'
+    fi
 else
     echo "pyenv: pyenv-jupyter-kernel plugin requires pyenv v0.1.0 or later" >&2
 fi

--- a/etc/pyenv.d/virtualenv/register-jupyter-kernel.bash
+++ b/etc/pyenv.d/virtualenv/register-jupyter-kernel.bash
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-if declare -Ff after_virtualenv >/dev/null; then
-  after_virtualenv 'pyenv register-kernel ${VIRTUALENV_NAME##*/}'
-else
-  echo "pyenv: pyenv-jupyter-kernel plugin requires pyenv-virtualenv v20130527 or later" >&2
-fi


### PR DESCRIPTION
It fixes #1 and #2 .The actual cause of this bug is the incorrect assumption that `jupyter` must be installed in the global versions. So, instead of automatically updating the kernel in all existing virtualenvs, I changed it to manually register the kernel using `register-kernel`.

It might resolve https://github.com/aiguofer/pyenv-jupyter-kernel/pull/6, too.

## Pros
* It fixes all problems in the issue.

## Cons
* You need to execute `pyenv register-kernel` after `pip install jupyter` by yourself.